### PR TITLE
[codex] Guard zero division in evaluator

### DIFF
--- a/evaluator/expression.cpp
+++ b/evaluator/expression.cpp
@@ -345,12 +345,16 @@ std::shared_ptr<Object> Evaluator::eval_integer_infix_expression(const TokenType
             throw std::runtime_error("ZeroDivisionError: division by zero");
         return std::make_shared<Ob_Fraction>(l, r);
     case TokenType::SLASH_SLASH:
+        if (r == 0)
+            throw std::runtime_error("ZeroDivisionError: integer division by zero");
         left->m_int = l / r;
         return left;
     case TokenType::STAR_STAR:
         left->m_int = std::pow(l, r);
         return left;
     case TokenType::PERCENT:
+        if (r == 0)
+            throw std::runtime_error("ZeroDivisionError: modulo by zero");
         left->m_int = l % r;
         return left;
     case TokenType::DOT: // 分数
@@ -425,12 +429,18 @@ std::shared_ptr<Object> Evaluator::eval_fraction_infix_expression(const TokenTyp
     case TokenType::STAR:
         return std::make_shared<Ob_Fraction>(Ob_Fraction::mul(l, r));
     case TokenType::SLASH:
+        if (r->num == 0)
+            throw std::runtime_error("ZeroDivisionError: division by zero");
         return std::make_shared<Ob_Fraction>(Ob_Fraction::div(l, r));
     case TokenType::SLASH_SLASH:
+        if (r->num == 0)
+            throw std::runtime_error("ZeroDivisionError: integer division by zero");
         return std::make_shared<Ob_Integer>(Ob_Fraction::div(l, r).m_int);
     case TokenType::STAR_STAR:
         return std::make_shared<Ob_Fraction>(Ob_Fraction::pow(l, r));
     case TokenType::PERCENT:
+        if (r->num == 0)
+            throw std::runtime_error("ZeroDivisionError: modulo by zero");
         return std::make_shared<Ob_Fraction>(Ob_Fraction::mod(l, r));
     case TokenType::EQUAL_EQUAL:
         return std::make_shared<Ob_Boolean>(l->equal(r));


### PR DESCRIPTION
## Summary

Guard evaluator division paths against zero right-hand operands before performing C++ integer division, modulo, or fraction division/modulo operations.

## Root cause

`/` for integer operands already raised `ZeroDivisionError`, but integer `//` and `%` used `l / r` and `l % r` directly. Fraction `/`, `//`, and `%` could also flow into `Ob_Fraction::div` or `Ob_Fraction::mod` with a zero numerator on the right-hand side. Those cases can trigger undefined behavior or produce invalid zero-denominator fractions instead of a language-level runtime error.

## Change

- Add zero checks for integer `//` and `%`.
- Add zero checks for fraction `/`, `//`, and `%`.
- Reuse `ZeroDivisionError`-style runtime errors so callers hit the existing exception handling path.

## Validation

- Inspected the branch diff: one file changed, `evaluator/expression.cpp`, with 10 added lines.
- Build/runtime tests were not run locally because this environment blocks terminal access to GitHub clone/download URLs and does not have `gh` installed; the change was applied through the GitHub connector.