### PR TITLE
Optimize C++ interpreter hot paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,17 @@ set(CMAKE_BUILD_TYPE Release)
 
 set(BUILD_SHARED_LIBS OFF)
 set(CMAKE_C_FLAGS_RELEASE "-O3")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 # set(CMAKE_VERBOSE_MAKEFILE ON)
+
+include(CheckIPOSupported)
+check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT IPO_ERROR)
 
 if (MSVC)
     add_compile_options(/utf-8)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /O2")
+else()
+    add_compile_options(-march=native)
 endif()
 
 
@@ -42,6 +47,9 @@ target_link_libraries(evaluator PUBLIC parser object)
 # Add the main executable
 add_executable(Ewhu Ewhu.cpp)
 target_compile_options(Ewhu PRIVATE -O3)
+if (IPO_SUPPORTED)
+    set_property(TARGET lexer object ast parser evaluator Ewhu PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+endif()
 
 # Link the libraries to the executable
 target_link_libraries(Ewhu PUBLIC evaluator lexer object parser ast)

--- a/evaluator/expression.cpp
+++ b/evaluator/expression.cpp
@@ -3,6 +3,19 @@
 #include "../parser/parser.h"
 #include <cmath>
 
+namespace
+{
+const int BUILTIN_APPEND = Parser::hash("append");
+const int BUILTIN_LEN = Parser::hash("len");
+const int BUILTIN_PRINT = Parser::hash("print");
+const int BUILTIN_EVAL = Parser::hash("eval");
+const int BUILTIN_SCOPE = Parser::hash("scope");
+const int BUILTIN_POP = Parser::hash("pop");
+const int BUILTIN_INT = Parser::hash("int");
+const int BUILTIN_INPUT = Parser::hash("input");
+const int BUILTIN_AST = Parser::hash("__ast__");
+}
+
 std::shared_ptr<Object> Evaluator::eval_eval(const std::string &line, Scope &scp)
 {
     Lexer lexer;
@@ -38,11 +51,11 @@ std::shared_ptr<Object> Evaluator::eval_function(const std::shared_ptr<Node> &no
             }
         }
 
-        if (name == Parser::prehash("append"))
+        if (name == BUILTIN_APPEND)
         {
             return eval_append(node, scp);
         }
-        if (name == Parser::prehash("len"))
+        if (name == BUILTIN_LEN)
         {
             auto obj = eval(node->m_initial_list[0], scp);
             if (obj->type() == Object::OBJECT_ARRAY)
@@ -51,33 +64,33 @@ std::shared_ptr<Object> Evaluator::eval_function(const std::shared_ptr<Node> &no
             }
             throw std::invalid_argument("Evaluator:eval_function: function len arguments not match");
         }
-        if (name == Parser::prehash("print"))
+        if (name == BUILTIN_PRINT)
         {
             std::cout << eval(node->m_initial_list[0], scp)->str() << std::endl;
             return nullptr;
         }
-        if (name == Parser::prehash("eval"))
+        if (name == BUILTIN_EVAL)
         {
             return eval_eval(eval(node->m_initial_list[0], scp)->str(), scp);
         }
-        if (name == Parser::prehash("scope"))
+        if (name == BUILTIN_SCOPE)
         {
             scp.print(identifier_map, function_map);
             return nullptr;
         }
-        if (name == Parser::prehash("pop"))
+        if (name == BUILTIN_POP)
         {
             return eval_pop(node, scp);
         }
-        if (name == Parser::prehash("int"))
+        if (name == BUILTIN_INT)
         {
             return eval_int(node, scp);
         }
-        if (name == Parser::prehash("input"))
+        if (name == BUILTIN_INPUT)
         {
             return eval_input(node, scp);
         }
-        if (name == Parser::prehash("__ast__"))
+        if (name == BUILTIN_AST)
         {
             // return eval_ast();
         }
@@ -284,6 +297,7 @@ std::shared_ptr<Object> Evaluator::eval_infix(const TokenType op, std::shared_pt
         switch (op)
         {
         case TokenType::STAR:
+            result.reserve(l.size() * static_cast<std::size_t>(r > 0 ? r : 0));
             for (int i = 0; i < r; i++)
                 result += l;
             return std::make_shared<Ob_String>(result);

--- a/evaluator/scope.h
+++ b/evaluator/scope.h
@@ -15,14 +15,7 @@ public:
     Scope(Scope *father) : father(father) {}
 
     Scope() {}
-    ~Scope()
-    {
-        for (auto it : m_var)
-        {
-            it.second.reset();
-        }
-        m_var.clear();
-    };
+    ~Scope() = default;
     void print(std::unordered_map<int, std::string> *var_map, std::unordered_map<int, std::string> *func_map)
     {
         std::cout << "Scope: " << std::endl;

--- a/evaluator/statement.cpp
+++ b/evaluator/statement.cpp
@@ -31,13 +31,7 @@ std::shared_ptr<Object> Evaluator::eval_function_block(const std::shared_ptr<Nod
     for (int i = 0; i < function->m_initial_list.size(); i++)
     {
         auto name = function->m_initial_list[i]->m_name;
-
-        auto it = temp_scp.m_var.find(name);
-        if (it != temp_scp.m_var.end())
-        {
-            it->second = eval(node->m_initial_list[i], temp_scp);
-        }
-        temp_scp.m_var.insert(std::make_pair(name, eval(node->m_initial_list[i], temp_scp)));
+        temp_scp.m_var[name] = eval(node->m_initial_list[i], temp_scp);
     }
 
     std::shared_ptr<Object> result;

--- a/object/object.h
+++ b/object/object.h
@@ -437,8 +437,11 @@ public:
 
     std::shared_ptr<Object> add(const std::shared_ptr<Object> &obj)
     {
-        m_array.insert(m_array.end(), obj->m_array.begin(), obj->m_array.end());
-        return std::make_shared<Ob_Array>(*this);
+        auto result = std::make_shared<Ob_Array>();
+        result->m_array.reserve(m_array.size() + obj->m_array.size());
+        result->m_array.insert(result->m_array.end(), m_array.begin(), m_array.end());
+        result->m_array.insert(result->m_array.end(), obj->m_array.begin(), obj->m_array.end());
+        return result;
     }
     virtual std::string str() const
     {

--- a/parser/parser.cpp
+++ b/parser/parser.cpp
@@ -1,39 +1,41 @@
 #include "parser.h"
 
-std::map<TokenType, int> Parser::m_precedences =
-    {
-        {TokenType::EQUAL, ASSIGN},
+std::array<int, 256> Parser::m_precedences = [] {
+    std::array<int, 256> precedences{};
+    precedences.fill(LOWEST);
+    precedences[static_cast<unsigned char>(TokenType::EQUAL)] = ASSIGN;
 
-        {TokenType::AND, LOGICAL},
-        {TokenType::OR, LOGICAL},
-        {TokenType::XOR, LOGICAL},
+    precedences[static_cast<unsigned char>(TokenType::AND)] = LOGICAL;
+    precedences[static_cast<unsigned char>(TokenType::OR)] = LOGICAL;
+    precedences[static_cast<unsigned char>(TokenType::XOR)] = LOGICAL;
 
-        {TokenType::SHL, BIT},
-        {TokenType::SHR, BIT},
-        {TokenType::BIT_XOR, BIT},
-        {TokenType::BIT_AND, BIT},
-        {TokenType::BIT_OR, BIT},
+    precedences[static_cast<unsigned char>(TokenType::SHL)] = BIT;
+    precedences[static_cast<unsigned char>(TokenType::SHR)] = BIT;
+    precedences[static_cast<unsigned char>(TokenType::BIT_XOR)] = BIT;
+    precedences[static_cast<unsigned char>(TokenType::BIT_AND)] = BIT;
+    precedences[static_cast<unsigned char>(TokenType::BIT_OR)] = BIT;
 
-        {TokenType::EQUAL_EQUAL, EQUALS},
-        {TokenType::BANG_EQUAL, EQUALS},
-        {TokenType::LESS, EQUALS},
-        {TokenType::GREATER, EQUALS},
-        {TokenType::LESS_EQUAL, EQUALS},
-        {TokenType::GREATER_EQUAL, EQUALS},
+    precedences[static_cast<unsigned char>(TokenType::EQUAL_EQUAL)] = EQUALS;
+    precedences[static_cast<unsigned char>(TokenType::BANG_EQUAL)] = EQUALS;
+    precedences[static_cast<unsigned char>(TokenType::LESS)] = EQUALS;
+    precedences[static_cast<unsigned char>(TokenType::GREATER)] = EQUALS;
+    precedences[static_cast<unsigned char>(TokenType::LESS_EQUAL)] = EQUALS;
+    precedences[static_cast<unsigned char>(TokenType::GREATER_EQUAL)] = EQUALS;
 
-        {TokenType::MINUS, SUM},
-        {TokenType::PLUS, SUM},
+    precedences[static_cast<unsigned char>(TokenType::MINUS)] = SUM;
+    precedences[static_cast<unsigned char>(TokenType::PLUS)] = SUM;
 
-        {TokenType::STAR, PRODUCT},
-        {TokenType::SLASH, PRODUCT},
-        {TokenType::PERCENT, PRODUCT},
-        {TokenType::SLASH_SLASH, PRODUCT},
+    precedences[static_cast<unsigned char>(TokenType::STAR)] = PRODUCT;
+    precedences[static_cast<unsigned char>(TokenType::SLASH)] = PRODUCT;
+    precedences[static_cast<unsigned char>(TokenType::PERCENT)] = PRODUCT;
+    precedences[static_cast<unsigned char>(TokenType::SLASH_SLASH)] = PRODUCT;
 
-        {TokenType::STAR_STAR, POWER},
+    precedences[static_cast<unsigned char>(TokenType::STAR_STAR)] = POWER;
 
-        {TokenType::DOT, DOT},
-        {TokenType::LEFT_BRACKET, INDEX},
-};
+    precedences[static_cast<unsigned char>(TokenType::DOT)] = DOT;
+    precedences[static_cast<unsigned char>(TokenType::LEFT_BRACKET)] = INDEX;
+    return precedences;
+}();
 std::unordered_map<TokenType, Parser::prefix_parse_fn> Parser::m_prefix_parse_fns =
     {
         {TokenType::TRUE, &Parser::parse_boolean},
@@ -159,20 +161,12 @@ void Parser::peek_error(TokenType type)
 
 int Parser::curr_token_precedence()
 {
-    auto it = m_precedences.find(m_curr.type);
-    if (it != m_precedences.end())
-        return it->second;
-    else
-        return LOWEST;
+    return m_precedences[static_cast<unsigned char>(m_curr.type)];
 }
 
 int Parser::peek_token_precedence()
 {
-    auto it = m_precedences.find(m_peek.type);
-    if (it != m_precedences.end())
-        return it->second;
-    else
-        return LOWEST;
+    return m_precedences[static_cast<unsigned char>(m_peek.type)];
 }
 
 void Parser::no_prefix_parse_fn_error(TokenType type)

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <map>
+#include <array>
 #include <list>
 #include <memory>
 #include <unordered_map>
@@ -105,7 +105,7 @@ private:
     Token m_peek;                    // 下一个token
     std::list<std::string> m_errors; // 存储错误的列表
 
-    static std::map<TokenType, int> m_precedences; // 一个从运算符TokenType类型到优先级类型的映射
+    static std::array<int, 256> m_precedences; // 一个从运算符TokenType类型到优先级类型的映射
     static std::unordered_map<TokenType, prefix_parse_fn> m_prefix_parse_fns;
     static std::unordered_map<TokenType, infix_parse_fn> m_infix_parse_fns;
     static std::unordered_map<TokenType, suffix_parse_fn> m_suffix_parse_fns;


### PR DESCRIPTION
### Motivation
- Reduce runtime overhead on hot parsing/evaluation paths and enable stronger Release optimizations to improve interpreter performance.

### Description
- Improve build optimizations in `CMakeLists.txt` by adding `-DNDEBUG`, applying `-march=native` for non-MSVC builds, and enabling release IPO/LTO when supported by CMake via `check_ipo_supported` and `set_property` for targets.
- Replace `std::map` precedence lookup with a fixed-size `std::array<int,256>` table in `parser` and switch to direct-index precedence queries to eliminate map lookup overhead in expression parsing (`parser/parser.h`, `parser/parser.cpp`).
- Cache builtin function name hashes in an anonymous namespace to avoid repeated `prehash`/`hash` recalculation at each call site and replace string compares with integer compares (`evaluator/expression.cpp`).
- Reduce evaluator overhead: evaluate each function argument once and assign to the parameter (`evaluator/statement.cpp`), remove manual `Scope` destructor cleanup to let RAII handle `shared_ptr`s (`evaluator/scope.h`), and reserve capacity before string repetition and array concatenation to avoid repeated reallocations (`evaluator/expression.cpp`, `object/object.h`).

### Testing
- Ran configuration and build with `cmake -S . -B build` and `cmake --build build -j2`, which completed successfully.
- Executed interpreter benchmarks `./build/Ewhu bench/fib27.ewhu` and `./build/Ewhu bench/bench_100000_while.ewhu`, both completed and produced expected outputs.
- Ran `for f in bench/*.ewhu; do ./build/Ewhu "$f" >/tmp/ewhu.out && tail -n 5 /tmp/ewhu.out; done` to exercise all bench scripts; most benchmarks completed, but `bench/recursion.ewhu` (intentionally unbounded recursion) caused a segmentation fault due to stack overflow, which is expected for that test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c70779bc083219ff5416ff35a4a59)